### PR TITLE
Register non-OSS dependancy as a contrib package for `dwave install`

### DIFF
--- a/dwave/inspector/package_info.py
+++ b/dwave/inspector/package_info.py
@@ -27,3 +27,18 @@ __description__ = 'D-Wave Problem Inspector tool'
 __url__ = 'https://github.com/dwavesystems/dwave-inspector'
 __license__ = 'Apache 2.0'
 __copyright__ = '2019, D-Wave Systems Inc.'
+
+
+# register the non-open-source packages required for dwave-inspector to work
+contrib = [{
+    'name': 'inspector',
+    'title': 'D-Wave Problem Inspector',
+    'description': 'This tool visualizes problems submitted to the quantum computer and the results returned.',
+    'license': {
+        'name': 'D-Wave EULA',
+        'url': 'https://docs.ocean.dwavesys.com/eula',
+    },
+    'requirements': [
+        'dwave-inspectorapp>=0.1.0',
+    ]
+}]

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,9 @@ setup(
         'inspectorapp_viewers': [
             'browser_tab = dwave.inspector.viewers:webbrowser_tab',
             'browser_window = dwave.inspector.viewers:webbrowser_window',
+        ],
+        'dwave_contrib': [
+            'dwave-inspector = dwave.inspector.package_info:contrib'
         ]
     },
     install_requires=install_requires,


### PR DESCRIPTION
For details on dwave contrib mechanism, check dwave-cloud-client#363.