### PR TITLE
Use generalized number of occurrences on client's Future

### DIFF
--- a/dwave/inspector/adapters.py
+++ b/dwave/inspector/adapters.py
@@ -350,7 +350,7 @@ def from_qmi_response(problem, response, embedding_context=None, warnings=None,
 
     solutions = list(map(itemgetter(*active_variables), response['solutions']))
     energies = response['energies']
-    num_occurrences = response['num_occurrences']
+    num_occurrences = response.occurrences
     num_variables = solver.num_qubits
     timing = response.timing
 
@@ -448,7 +448,7 @@ def from_bqm_response(bqm, embedding_context, response, warnings=None,
 
     solutions = list(map(itemgetter(*active_variables), response['solutions']))
     energies = response['energies']
-    num_occurrences = response['num_occurrences']
+    num_occurrences = response.occurrences
     num_variables = solver.num_qubits
     timing = response.timing
 


### PR DESCRIPTION
This ensures `answer_mode='raw'` is handled properly, as in that case
the response from SAPI does not contain 'num_occurrences' field.

Closes #23.