### PR TITLE
Fix old solvers support

### DIFF
--- a/dwave/inspector/adapters.py
+++ b/dwave/inspector/adapters.py
@@ -91,11 +91,14 @@ def _get_solver_topology(solver, default=None):
     """
 
     try:
-        return solver.properties['topology']['type'].lower()
+        # get topology, verifying structure
+        topology = solver.properties['topology']
+        _, _ = topology['type'], topology['shape']
+        return topology
 
     except KeyError:
         if hasattr(solver, 'edges') and hasattr(solver, 'nodes'):
-            return 'chimera'
+            return {'type': 'chimera', 'shape': [16, 16, 4]}
 
     return default
 
@@ -356,8 +359,8 @@ def from_qmi_response(problem, response, embedding_context=None, warnings=None,
     if not isinstance(response.solver, StructuredSolver):
         raise TypeError("only structured solvers are supported")
 
-    topology_type = _get_solver_topology(solver)
-    if topology_type not in SUPPORTED_SOLVER_TOPOLOGY_TYPES:
+    topology = _get_solver_topology(solver)
+    if topology['type'] not in SUPPORTED_SOLVER_TOPOLOGY_TYPES:
         raise TypeError("unsupported solver topology type")
 
     solver_id = solver.id
@@ -460,8 +463,8 @@ def from_bqm_response(bqm, embedding_context, response, warnings=None,
     if not isinstance(response.solver, StructuredSolver):
         raise TypeError("only structured solvers are supported")
 
-    topology_type = _get_solver_topology(solver)
-    if topology_type not in SUPPORTED_SOLVER_TOPOLOGY_TYPES:
+    topology = _get_solver_topology(solver)
+    if topology['type'] not in SUPPORTED_SOLVER_TOPOLOGY_TYPES:
         raise TypeError("unsupported solver topology type")
 
     solver_id = solver.id
@@ -614,8 +617,8 @@ def from_bqm_sampleset(bqm, sampleset, sampler, embedding_context=None,
     if not isinstance(solver, StructuredSolver):
         raise TypeError("only structured solvers are supported")
 
-    topology_type = _get_solver_topology(solver)
-    if topology_type not in SUPPORTED_SOLVER_TOPOLOGY_TYPES:
+    topology = _get_solver_topology(solver)
+    if topology['type'] not in SUPPORTED_SOLVER_TOPOLOGY_TYPES:
         raise TypeError("unsupported solver topology type")
 
     solver_id = solver.id

--- a/dwave/inspector/adapters.py
+++ b/dwave/inspector/adapters.py
@@ -102,15 +102,19 @@ def _get_solver_topology(solver, default=None):
 
     return default
 
-def solver_data_modernized(solver):
-    """Returns (possibly an old) solver's updated `data` that include the
-    missing properties like topology. Does not modify existing properties.
+def solver_data_postprocessed(solver):
+    """Returns (possibly an old) solver's updated `data` that includes the
+    missing properties like topology. Also, removes large unused properties.
     """
 
     # make a copy to avoid modifying the original solver.data
     data = copy.deepcopy(solver.data)
 
+    # add missing but used properties
     data['properties'].setdefault('topology', _get_solver_topology(solver))
+
+    # remove unused properties
+    del data['properties']['anneal_offset_ranges']
 
     return data
 

--- a/dwave/inspector/adapters.py
+++ b/dwave/inspector/adapters.py
@@ -342,7 +342,8 @@ def from_qmi_response(problem, response, embedding_context=None, warnings=None,
     """
     logger.debug("from_qmi_response({!r})".format(
         dict(problem=problem, response=response, response_energies=response['energies'],
-             embedding_context=embedding_context, warnings=warnings, params=params)))
+             embedding_context=embedding_context, warnings=warnings,
+             params=params, sampleset=sampleset)))
 
     try:
         linear, quadratic = problem
@@ -457,7 +458,8 @@ def from_bqm_response(bqm, embedding_context, response, warnings=None,
     """
     logger.debug("from_bqm_response({!r})".format(
         dict(bqm=bqm, response=response, response_energies=response['energies'],
-             embedding_context=embedding_context, warnings=warnings, params=params)))
+             embedding_context=embedding_context, warnings=warnings,
+             params=params, sampleset=sampleset)))
 
     solver = response.solver
     if not isinstance(response.solver, StructuredSolver):

--- a/dwave/inspector/adapters.py
+++ b/dwave/inspector/adapters.py
@@ -102,6 +102,18 @@ def _get_solver_topology(solver, default=None):
 
     return default
 
+def solver_data_modernized(solver):
+    """Returns (possibly an old) solver's updated `data` that include the
+    missing properties like topology. Does not modify existing properties.
+    """
+
+    # make a copy to avoid modifying the original solver.data
+    data = copy.deepcopy(solver.data)
+
+    data['properties'].setdefault('topology', _get_solver_topology(solver))
+
+    return data
+
 
 def _answer_dict(solutions, active_variables, energies, num_occurrences, timing, num_variables):
     return {

--- a/dwave/inspector/storage.py
+++ b/dwave/inspector/storage.py
@@ -15,7 +15,7 @@
 import threading
 from collections import OrderedDict, defaultdict
 
-from dwave.inspector.adapters import solver_data_modernized
+from dwave.inspector.adapters import solver_data_postprocessed
 
 
 # dict[problem_id: str, problem_data: dict]
@@ -107,6 +107,6 @@ def get_solver_data(solver_id):
     any of the problems cached so far, fail with :exc:`KeyError`.
     """
     if solver_id in solvers:
-        return solver_data_modernized(solvers[solver_id])
+        return solver_data_postprocessed(solvers[solver_id])
 
     raise KeyError('solver not found')

--- a/dwave/inspector/storage.py
+++ b/dwave/inspector/storage.py
@@ -15,6 +15,8 @@
 import threading
 from collections import OrderedDict, defaultdict
 
+from dwave.inspector.adapters import solver_data_modernized
+
 
 # dict[problem_id: str, problem_data: dict]
 problem_store = OrderedDict()
@@ -105,6 +107,6 @@ def get_solver_data(solver_id):
     any of the problems cached so far, fail with :exc:`KeyError`.
     """
     if solver_id in solvers:
-        return solvers[solver_id].data
+        return solver_data_modernized(solvers[solver_id])
 
     raise KeyError('solver not found')

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -82,6 +82,9 @@ class TestAdapters(unittest.TestCase):
             self.response = self.solver.sample_ising(*self.problem, **self.params)
 
     def verify_data_encoding(self, problem, response, solver, params, data, embedding_context=None):
+        # avoid persistent data modification
+        data = data.copy()
+
         # make sure data correct after JSON decoding (minus the 'rel' data)
         del data['rel']
         data = json.loads(json.dumps(data))

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,67 @@
+# Copyright 2020 D-Wave Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+from functools import partial
+
+import vcr
+
+from dwave.cloud import Client
+
+from dwave.inspector.storage import push_inspector_data, get_solver_data
+
+
+rec = vcr.VCR(
+    serializer='yaml',
+    cassette_library_dir='tests/fixtures/cassettes',
+    record_mode='none',
+    match_on=['uri', 'method'],
+    filter_headers=['x-auth-token'],
+)
+
+
+# we can use a fake token because outbound requests are intercepted anyway
+BrickedClient = partial(Client, token='fake')
+
+
+@mock.patch('dwave.system.samplers.dwave_sampler.Client.from_config', BrickedClient)
+class TestStorage(unittest.TestCase):
+
+    @rec.use_cassette('triangle-ising.yaml')
+    def test_solver_modernization(self):
+        """Solver's data is "modernized", i.e. missing props are added."""
+
+        # get real solver
+        with BrickedClient() as client:
+            solver = client.get_solver(qpu=True)
+
+        # cripple it
+        del solver.properties['topology']
+
+        # mock minimal data adapter response
+        inspector_data = {'rel': {'solver': solver}, 'details': {'id': 'mock-id'}}
+
+        # store it
+        push_inspector_data(inspector_data)
+
+        # get solver data
+        solver_data = get_solver_data(solver.id)
+
+        # verify missing data is recreated
+        self.assertIn('topology', solver_data['properties'])
+        self.assertEqual(solver_data['properties']['topology']['type'], 'chimera')
+
+        # verify the original solver data is intact
+        self.assertNotIn('topology', solver.properties)


### PR DESCRIPTION
Closes #91.
Closes #95.

This PR, together with #92, adds support for old solvers in both Python and JS parts of the inspector.