### PR TITLE
Improve problem access waiting

### DIFF
--- a/dwave/inspector/__init__.py
+++ b/dwave/inspector/__init__.py
@@ -79,7 +79,7 @@ def open_problem(problem_id, block=Block.ONCE, timeout=None):
             by :class:`Block` value.
 
         timeout (float):
-            Blocking behavior timeout.
+            Blocking behavior timeout in seconds.
 
     """
     # accept string name for `block`

--- a/dwave/inspector/__init__.py
+++ b/dwave/inspector/__init__.py
@@ -50,17 +50,16 @@ enable_data_capture()
 
 
 class Block(enum.Enum):
-    """
-    Flow-control settings for scripts.
+    """Flow-control settings for scripts.
 
     An enum with values: ``NEVER``, ``ONCE``, ``FOREVER``. The default setting of
     ``once`` (``dwave.inspector.Block.ONCE``) blocks until your problem
-    is loaded from the inspector web server
+    is loaded from the inspector web server.
 
     Examples:
         This example does not block while the problem is loaded.
 
-    >>> dwave.inspector.show(response, block='never')   # doctest: +SKIP
+        >>> dwave.inspector.show(response, block='never')   # doctest: +SKIP
 
     """
     NEVER = 'never'
@@ -68,7 +67,7 @@ class Block(enum.Enum):
     FOREVER = 'forever'
 
 
-def open_problem(problem_id, block=Block.ONCE):
+def open_problem(problem_id, block=Block.ONCE, timeout=None):
     """Open the problem inspector for the specified problem.
 
     Args:
@@ -78,6 +77,9 @@ def open_problem(problem_id, block=Block.ONCE):
         block (:class:`Block`/str/bool, optional, default: :obj:`Block.ONCE`):
             Blocking behavior after opening up the web browser preview as set
             by :class:`Block` value.
+
+        timeout (float):
+            Blocking behavior timeout.
 
     """
     # accept string name for `block`
@@ -91,9 +93,9 @@ def open_problem(problem_id, block=Block.ONCE):
     view(url)
 
     if block is Block.ONCE:
-        app_server.wait_problem_accessed(problem_id)
+        app_server.wait_problem_accessed(problem_id, timeout=timeout)
     elif block is Block.FOREVER or block is True:
-        app_server.wait_shutdown()
+        app_server.wait_shutdown(timeout=timeout)
 
     return url
 
@@ -175,6 +177,7 @@ def show(*args, **kwargs):
 
     """
     block = kwargs.pop('block', Block.ONCE)
+    timeout = kwargs.pop('timeout', None)
     data = from_objects(*args, **kwargs)
     id_ = push_inspector_data(data)
-    return open_problem(id_, block=block)
+    return open_problem(id_, block=block, timeout=timeout)

--- a/dwave/inspector/adapters.py
+++ b/dwave/inspector/adapters.py
@@ -851,4 +851,4 @@ def from_objects(*args, **kwargs):
     raise ValueError(
         "invalid combination of arguments provided: if data capture not "
         "enabled, problem/response/solver have to be specified; "
-        "also, make sure a structured problem is inspected")
+        "also, make sure a structured problem is being inspected")

--- a/dwave/inspector/server.py
+++ b/dwave/inspector/server.py
@@ -186,8 +186,8 @@ class WSGIAsyncServer(threading.Thread):
         if self.is_alive():
             self.stop()
 
-    def wait_shutdown(self):
-        self.join()
+    def wait_shutdown(self, timeout=None):
+        self.join(timeout)
 
     def wait_problem_accessed(self, problem_id, timeout=None):
         """Blocks until problem access semaphore is notified.

--- a/dwave/inspector/server.py
+++ b/dwave/inspector/server.py
@@ -27,7 +27,7 @@ except ImportError:
     import importlib.resources as importlib_resources
 
 import requests
-from flask import Flask, send_from_directory
+from flask import Flask, send_from_directory, make_response
 from werkzeug.exceptions import NotFound
 
 from dwave.inspector.storage import problem_store, problem_access_sem, get_problem, get_solver_data
@@ -232,7 +232,9 @@ def send_solver(problem_id):
 @app.route('/api/callback/<problem_id>')
 def notify_problem_loaded(problem_id):
     app_server.notify_problem_accessed(problem_id)
-    return dict(ack=True)
+    resp = make_response(dict(ack=True))
+    resp.headers['Cache-Control'] = 'no-cache'
+    return resp
 
 @app.after_request
 def add_header(response):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,3 +11,43 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from time import perf_counter
+
+# NOTE: copied from dwave-hybrid
+# TODO: Remove/replace when dwave.common utility package is created
+class RunTimeAssertionMixin:
+    """unittest.TestCase mixin that adds min/max/range run-time assert."""
+
+    class assertRuntimeWithin:
+
+        def __init__(self, low, high):
+            """Min/max runtime in milliseconds."""
+            self.limits = (low, high)
+
+        def __enter__(self):
+            self.tick = perf_counter()
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            self.dt = (perf_counter() - self.tick) * 1000.0
+            self.test()
+
+        def test(self):
+            low, high = self.limits
+            if low is not None and self.dt < low:
+                raise AssertionError("Min runtime unreached: %g ms < %g ms" % (self.dt, low))
+            if high is not None and self.dt > high:
+                raise AssertionError("Max runtime exceeded: %g ms > %g ms" % (self.dt, high))
+
+    class assertMinRuntime(assertRuntimeWithin):
+
+        def __init__(self, t):
+            """Min runtime in milliseconds."""
+            self.limits = (t, None)
+
+    class assertMaxRuntime(assertRuntimeWithin):
+
+        def __init__(self, t):
+            """Max runtime in milliseconds."""
+            self.limits = (None, t)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,11 +13,33 @@
 # limitations under the License.
 
 import unittest
+from functools import partial
+from concurrent.futures import ThreadPoolExecutor
+
+import vcr
+import requests
+
+from dwave.cloud import Client
 
 from dwave.inspector.server import app_server
+from dwave.inspector import show, Block
+
+from tests import RunTimeAssertionMixin
 
 
-class TestServer(unittest.TestCase):
+rec = vcr.VCR(
+    serializer='yaml',
+    cassette_library_dir='tests/fixtures/cassettes',
+    record_mode='none',
+    match_on=['uri', 'method'],
+    filter_headers=['x-auth-token'],
+    ignore_localhost=True,
+)
+
+BrickedClient = partial(Client, token='fake')
+
+
+class TestServerRuns(unittest.TestCase):
 
     def test_lazy_start(self):
         self.assertIsNone(getattr(app_server, '_server', None))
@@ -25,4 +47,43 @@ class TestServer(unittest.TestCase):
 
     def test_smoke(self):
         self.assertTrue(app_server.ensure_started())
-        app_server.stop()
+        # NOTE: we shouldn't test app_server.stop() if other tests need to run
+        # the server again, since currently our app server can be started ONLY
+        # ONCE per program run.
+
+
+@unittest.mock.patch('dwave.system.samplers.dwave_sampler.Client.from_config', BrickedClient)
+@unittest.mock.patch('dwave.inspector.view', lambda url: None)
+class TestServerWorks(unittest.TestCase, RunTimeAssertionMixin):
+
+    @rec.use_cassette('triangle-ising.yaml')
+    def test_blocking(self):
+
+        # sample (submitted problem irrelevant, response is prerecorded)
+        with BrickedClient() as client:
+            solver = client.get_solver(qpu=True)
+            response = solver.sample_qubo({(0, 4): 1, (1, 5): 1})
+            problem_id = response.wait_id()
+
+        # setup a "problem loaded" notifier
+        def problem_loaded(problem_id):
+            url = app_server.get_callback_url(problem_id)
+            return requests.get(url).json()
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+
+            # show shouldn't block regardless of problem inspector opening or not
+            with self.assertMaxRuntime(5000):
+                show(response, block=Block.NEVER)
+
+            # show blocks until first access
+            with self.assertMaxRuntime(5000):
+                # notify the inspector server the `problem_id` has been "viewed" by
+                # our mock browser/viewer (async)
+                fut = executor.submit(problem_loaded, problem_id=problem_id)
+                show(response, block=Block.ONCE)
+                fut.result()
+
+            # show blocks until timeout
+            with self.assertMaxRuntime(5000):
+                show(response, block=Block.ONCE, timeout=1)


### PR DESCRIPTION
Here we:
- fix #104 by disabling caching of problem access callback response, so that each problem load notifies the server, even for repeated loads of agent-cached problems;
- introduce `timeout` parameter in `dwave.inspector.show()` that works in conjunction with the `block` param to determine max wait time of `show()` for problem access.