### PR TITLE
Render inline in Jupyter notebooks

### DIFF
--- a/dwave/inspector/__init__.py
+++ b/dwave/inspector/__init__.py
@@ -100,13 +100,14 @@ def open_problem(problem_id, block=Block.ONCE, timeout=None):
     app_server.ensure_started()
     url = app_server.get_inspect_url(problem_id)
 
-    # open url and block if requested
-    view(url)
+    # open url and block
+    blockable = view(url)
 
-    if block is Block.ONCE:
-        app_server.wait_problem_accessed(problem_id, timeout=timeout)
-    elif block is Block.FOREVER or block is True:
-        app_server.wait_shutdown(timeout=timeout)
+    if blockable is not False:
+        if block is Block.ONCE:
+            app_server.wait_problem_accessed(problem_id, timeout=timeout)
+        elif block is Block.FOREVER or block is True:
+            app_server.wait_shutdown(timeout=timeout)
 
     return RichDisplay(url)
 

--- a/dwave/inspector/__init__.py
+++ b/dwave/inspector/__init__.py
@@ -67,6 +67,17 @@ class Block(enum.Enum):
     FOREVER = 'forever'
 
 
+class RichDisplay(str):
+    def __init__(self, url):
+        self.url = url
+
+    def _repr_pretty_(self, pp, cycle):
+        return pp.text(f'Serving Inspector on {self.url}')
+
+    def _repr_html_(self):
+        return f'<iframe src={self.url} width="100%" height=640></iframe>'
+
+
 def open_problem(problem_id, block=Block.ONCE, timeout=None):
     """Open the problem inspector for the specified problem.
 
@@ -97,7 +108,7 @@ def open_problem(problem_id, block=Block.ONCE, timeout=None):
     elif block is Block.FOREVER or block is True:
         app_server.wait_shutdown(timeout=timeout)
 
-    return url
+    return RichDisplay(url)
 
 
 def show_qmi(problem, response, embedding_context=None, warnings=None, params=None):

--- a/dwave/inspector/__init__.py
+++ b/dwave/inspector/__init__.py
@@ -102,8 +102,11 @@ def open_problem(problem_id, block=Block.ONCE, timeout=None):
     app_server.ensure_started()
     url = app_server.get_inspect_url(problem_id)
 
+    # add support for jupyter inline rendering
+    rich_url = RichDisplayURL(url)
+
     # open url and block
-    blockable = view(url)
+    blockable = view(rich_url)
 
     if blockable is not False:
         if block is Block.ONCE:
@@ -111,7 +114,7 @@ def open_problem(problem_id, block=Block.ONCE, timeout=None):
         elif block is Block.FOREVER or block is True:
             app_server.wait_shutdown(timeout=timeout)
 
-    return RichDisplayURL(url)
+    return rich_url
 
 
 def show_qmi(problem, response, embedding_context=None, warnings=None, params=None):

--- a/dwave/inspector/__init__.py
+++ b/dwave/inspector/__init__.py
@@ -67,15 +67,17 @@ class Block(enum.Enum):
     FOREVER = 'forever'
 
 
-class RichDisplay(str):
-    def __init__(self, url):
-        self.url = url
+class RichDisplayURL(str):
+    """Behaves as `str`, but provides support for rich display in Jupyter.
+
+    In console, the URL pretty-printed, and in GUI the URL is opened in an iframe.
+    """
 
     def _repr_pretty_(self, pp, cycle):
-        return pp.text(f'Serving Inspector on {self.url}')
+        return pp.text(f'Serving Inspector on {self}')
 
     def _repr_html_(self):
-        return f'<iframe src={self.url} width="100%" height=640></iframe>'
+        return f'<iframe src={self} width="100%" height=640></iframe>'
 
 
 def open_problem(problem_id, block=Block.ONCE, timeout=None):
@@ -109,7 +111,7 @@ def open_problem(problem_id, block=Block.ONCE, timeout=None):
         elif block is Block.FOREVER or block is True:
             app_server.wait_shutdown(timeout=timeout)
 
-    return RichDisplay(url)
+    return RichDisplayURL(url)
 
 
 def show_qmi(problem, response, embedding_context=None, warnings=None, params=None):

--- a/dwave/inspector/viewers.py
+++ b/dwave/inspector/viewers.py
@@ -47,7 +47,7 @@ def annotated(**kwargs):
 
 
 @annotated(priority=1000)
-def jupyter_nop(rich_url):
+def jupyter_inline(rich_url):
     """Hijack viewers (use high priority) and prevent browser popping up when
     running in interactive (GUI) Jupyter session. That way only the inline
     Inspector is shown.

--- a/dwave/inspector/viewers.py
+++ b/dwave/inspector/viewers.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 import logging
-import functools
-import webbrowser
 import operator
+import webbrowser
 from pkg_resources import iter_entry_points
 
 logger = logging.getLogger(__name__)
@@ -58,6 +57,9 @@ def jupyter_nop(url):
     logger.debug('Running inside ipython: %r', ipython)
     if 'ZMQInteractiveShell' not in type(ipython).__name__:
         raise ValueError('non-gui interactive shell')
+
+    # don't block if gui interactive shell is used
+    return False
 
 
 @annotated(priority=0)

--- a/dwave/inspector/viewers.py
+++ b/dwave/inspector/viewers.py
@@ -47,16 +47,21 @@ def annotated(**kwargs):
 
 
 @annotated(priority=1000)
-def jupyter_nop(url):
+def jupyter_nop(rich_url):
     """Hijack viewers (use high priority) and prevent browser popping up when
     running in interactive (GUI) Jupyter session. That way only the inline
     Inspector is shown.
     """
-    # note: it's fine to fail, the next viewer is tried in that case
+    # note: `get_ipython` is available without import since ipython 5.1
+    # (and it's fine to fail here, since the next viewer is attempted in that case)
     ipython = get_ipython()
     logger.debug('Running inside ipython: %r', ipython)
     if 'ZMQInteractiveShell' not in type(ipython).__name__:
         raise ValueError('non-gui interactive shell')
+
+    # render URL/IFrame inline in jupyter notebook, or fail trying
+    # note: since ipython 5.4/6.1 (May 2017) `display` is available without import
+    display(rich_url)
 
     # don't block if gui interactive shell is used
     return False

--- a/dwave/inspector/viewers.py
+++ b/dwave/inspector/viewers.py
@@ -94,4 +94,5 @@ def view(url):
             logger.info('Opening the webapp URL with %r failed with %r',
                         viewer.__name__, exc)
 
+    # caller should not block on server access, since no viewers opened
     return False

--- a/dwave/inspector/viewers.py
+++ b/dwave/inspector/viewers.py
@@ -47,9 +47,23 @@ def annotated(**kwargs):
     return _decorator
 
 
+@annotated(priority=1000)
+def jupyter_nop(url):
+    """Hijack viewers (use high priority) and prevent browser popping up when
+    running in interactive (GUI) Jupyter session. That way only the inline
+    Inspector is shown.
+    """
+    # note: it's fine to fail, the next viewer is tried in that case
+    ipython = get_ipython()
+    logger.debug('Running inside ipython: %r', ipython)
+    if 'ZMQInteractiveShell' not in type(ipython).__name__:
+        raise ValueError('non-gui interactive shell')
+
+
 @annotated(priority=0)
 def webbrowser_tab(url):
     return webbrowser.open_new_tab(url)
+
 
 @annotated(priority=-10)
 def webbrowser_window(url):

--- a/releasenotes/notes/support-jupyter-inline-c7b9b63bfe7a9b0a.yaml
+++ b/releasenotes/notes/support-jupyter-inline-c7b9b63bfe7a9b0a.yaml
@@ -1,0 +1,16 @@
+---
+features:
+  - |
+    Render inspector inline in Jupyter notebooks.
+    See `#109 <https://github.com/dwavesystems/dwave-inspector/issues/109>`_
+    and `#133 <https://github.com/dwavesystems/dwave-inspector/issues/133>`_.
+fixes:
+  - |
+    Make ``show()`` non-blocking regardless of the ``block`` argument when
+    no viewer manages to open the inspector page.
+    See `#139 <https://github.com/dwavesystems/dwave-inspector/issues/139>`_.
+upgrade:
+  - |
+    Custom viewer can now return ``False`` to signal a non-blocking ``show()``
+    behavior is desired. Previously the value returned was ignored by the
+    caller.

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     packages=packages,
     entry_points={
         'inspectorapp_viewers': [
-            'jupyter_nop = dwave.inspector.viewers:jupyter_nop',
+            'jupyter_inline = dwave.inspector.viewers:jupyter_inline',
             'browser_tab = dwave.inspector.viewers:webbrowser_tab',
             'browser_window = dwave.inspector.viewers:webbrowser_window',
         ],

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
     packages=packages,
     entry_points={
         'inspectorapp_viewers': [
+            'jupyter_nop = dwave.inspector.viewers:jupyter_nop',
             'browser_tab = dwave.inspector.viewers:webbrowser_tab',
             'browser_window = dwave.inspector.viewers:webbrowser_window',
         ],

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,9 +38,10 @@ rec = vcr.VCR(
 )
 
 
-class TestServerRuns(unittest.TestCase):
+class FirstTestServerRuns(unittest.TestCase):
 
     def test_lazy_start(self):
+        # note: this test has to run first
         self.assertIsNone(getattr(app_server, '_server', None))
         self.assertIsNotNone(app_server.server)
 
@@ -52,8 +53,7 @@ class TestServerRuns(unittest.TestCase):
 
 
 @unittest.mock.patch('dwave.system.samplers.dwave_sampler.Client.from_config', BrickedClient)
-@unittest.mock.patch('dwave.inspector.view', lambda url: None)
-class TestServerWorks(unittest.TestCase, RunTimeAssertionMixin):
+class TestProblemOpen(unittest.TestCase, RunTimeAssertionMixin):
 
     @rec.use_cassette('triangle-ising.yaml')
     @classmethod
@@ -69,6 +69,7 @@ class TestServerWorks(unittest.TestCase, RunTimeAssertionMixin):
         url = app_server.get_callback_url(problem_id)
         return requests.get(url).json()
 
+    @unittest.mock.patch('dwave.inspector.view', lambda url: None)
     def test_show_no_block(self):
         # exclude potential server start-up time from timing tests below
         app_server.ensure_started()
@@ -77,6 +78,7 @@ class TestServerWorks(unittest.TestCase, RunTimeAssertionMixin):
         with self.assertMaxRuntime(2000):
             show(self.response, block=Block.NEVER)
 
+    @unittest.mock.patch('dwave.inspector.view', lambda url: True)
     def test_show_block_once(self):
         # exclude potential server start-up time from timing tests below
         app_server.ensure_started()
@@ -90,6 +92,7 @@ class TestServerWorks(unittest.TestCase, RunTimeAssertionMixin):
                 show(self.response, block=Block.ONCE)
                 fut.result()
 
+    @unittest.mock.patch('dwave.inspector.view', lambda url: None)
     def test_show_block_timeout(self):
         # exclude potential server start-up time from timing tests below
         app_server.ensure_started()
@@ -101,7 +104,21 @@ class TestServerWorks(unittest.TestCase, RunTimeAssertionMixin):
         with self.assertMaxRuntime(2000):
             show(self.response, block=True, timeout=1)
 
+    @unittest.mock.patch('dwave.inspector.view', lambda url: False)
+    def test_show_blocking_ignored(self):
+        # exclude potential server start-up time from timing tests below
+        app_server.ensure_started()
+
+        # show shouldn't block regardless of problem inspector opening or not
+        with self.assertMaxRuntime(2000):
+            show(self.response, block=Block.ONCE)
+
+
+@unittest.mock.patch('dwave.system.samplers.dwave_sampler.Client.from_config', BrickedClient)
+class TestSerialization(unittest.TestCase):
+
     @rec.use_cassette('triangle-ising.yaml')
+    @unittest.mock.patch('dwave.inspector.view', lambda url: None)
     def test_numpy_types_serialized(self):
         # model and embedding use variables with numpy types
         h = {}

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -95,14 +95,14 @@ class TestViewers(unittest.TestCase):
     @mock.patch('dwave.inspector.viewers.get_ipython', DummyZMQInteractiveShell, create=True)
     @mock.patch('dwave.inspector.viewers.display', lambda o: None, create=True)
     def test_hijack(self):
-        """jupyter_nop viewer prevents blocking."""
+        """jupyter_inline viewer prevents blocking."""
 
         self.assertEqual(view('url'), False)
 
     @mock.patch('dwave.inspector.viewers.get_ipython', DummyZMQInteractiveShell, create=True)
     @mock.patch('dwave.inspector.viewers.display', create=True)
     def test_hijack(self, display):
-        """jupyter_nop viewer calls display."""
+        """jupyter_inline viewer calls display."""
 
         url = 'url'
         self.assertEqual(view(url), False)
@@ -111,7 +111,7 @@ class TestViewers(unittest.TestCase):
     @mock.patch('webbrowser.open_new_tab', return_value='webbrowser_tab')
     @mock.patch('dwave.inspector.viewers.get_ipython', object, create=True)
     def test_terminal_ipython(self, m):
-        """jupyter_nop viewer ignores non-gui ipython."""
+        """jupyter_inline viewer ignores non-gui ipython."""
 
         self.assertEqual(view('url'), 'webbrowser_tab')
 

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -56,6 +56,10 @@ class TestAnnotation(unittest.TestCase):
             self.assertEqual(getattr(f, k), v)
 
 
+class DummyZMQInteractiveShell:
+    pass
+
+
 class TestViewers(unittest.TestCase):
 
     def test_registration(self):
@@ -87,3 +91,16 @@ class TestViewers(unittest.TestCase):
         """Fallback to secondary viewer works when primary fails."""
 
         self.assertEqual(view('url'), 'webbrowser_window')
+
+    @mock.patch('dwave.inspector.viewers.get_ipython', DummyZMQInteractiveShell, create=True)
+    def test_hijack(self):
+        """jupyter_nop viewer prevents blocking."""
+
+        self.assertEqual(view('url'), False)
+
+    @mock.patch('webbrowser.open_new_tab', return_value='webbrowser_tab')
+    @mock.patch('dwave.inspector.viewers.get_ipython', object, create=True)
+    def test_terminal_ipython(self, m):
+        """jupyter_nop viewer ignores non-gui ipython."""
+
+        self.assertEqual(view('url'), 'webbrowser_tab')

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -104,3 +104,11 @@ class TestViewers(unittest.TestCase):
         """jupyter_nop viewer ignores non-gui ipython."""
 
         self.assertEqual(view('url'), 'webbrowser_tab')
+
+    @mock.patch('webbrowser.open_new_tab', side_effect=ValueError)
+    @mock.patch('webbrowser.open_new', side_effect=ValueError)
+    @mock.patch('dwave.inspector.viewers.get_ipython', side_effect=ValueError, create=True)
+    def test_nonblocking_view(self, m1, m2, m3):
+        """Signal non-blocking show behavior when no viewer succeeds."""
+
+        self.assertEqual(view('url'), False)

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -93,10 +93,20 @@ class TestViewers(unittest.TestCase):
         self.assertEqual(view('url'), 'webbrowser_window')
 
     @mock.patch('dwave.inspector.viewers.get_ipython', DummyZMQInteractiveShell, create=True)
+    @mock.patch('dwave.inspector.viewers.display', lambda o: None, create=True)
     def test_hijack(self):
         """jupyter_nop viewer prevents blocking."""
 
         self.assertEqual(view('url'), False)
+
+    @mock.patch('dwave.inspector.viewers.get_ipython', DummyZMQInteractiveShell, create=True)
+    @mock.patch('dwave.inspector.viewers.display', create=True)
+    def test_hijack(self, display):
+        """jupyter_nop viewer calls display."""
+
+        url = 'url'
+        self.assertEqual(view(url), False)
+        display.assert_called_once_with(url)
 
     @mock.patch('webbrowser.open_new_tab', return_value='webbrowser_tab')
     @mock.patch('dwave.inspector.viewers.get_ipython', object, create=True)


### PR DESCRIPTION
Add support for rich object display in Jupyter notebooks. This covers a local Jupyter install, as well as, for example, a local VSCode's Jupyter extension.

Interactive terminal shell still pops a preview in an external browser, but interactive ZMQ shell renders the Inspector inline using an iframe.

Close #109.
Close #133.
Close #139.

Note: support for hosted JupyterHub that uses [jupyter-server-proxy](https://jupyter-server-proxy.readthedocs.io/en/latest/arbitrary-ports-hosts.html) for port proxying will be implemented with #141.