### PR TITLE
Future-proof Flask JSON serialization

### DIFF
--- a/dwave/inspector/server.py
+++ b/dwave/inspector/server.py
@@ -32,7 +32,7 @@ from werkzeug.exceptions import NotFound
 
 from dwave.inspector.config import config
 from dwave.inspector.storage import problem_store, problem_access_sem, get_problem, get_solver_data
-from dwave.inspector.utils import NumpyEncoder
+from dwave.inspector.utils import NumpyJSONProvider
 
 
 # get local server/app logger
@@ -218,7 +218,7 @@ class WSGIAsyncServer(threading.Thread):
 
 
 app = Flask(__name__, static_folder=None)
-app.json_encoder = NumpyEncoder
+app.json = NumpyJSONProvider(app)
 
 @app.route('/')
 @app.route('/<path:path>')

--- a/releasenotes/notes/upgrade-flask-json-serialization-5fdfc185ef80b6e9.yaml
+++ b/releasenotes/notes/upgrade-flask-json-serialization-5fdfc185ef80b6e9.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - |
+    Lower bound on Flask version is now 2.2.
+fixes:
+  - |
+    Upgraded JSON serialization to use Flask's new ``DefaultJSONProvider``
+    (introduced in Flask 2.2). The "old" way is deprecated by Flask in 2.2, to be
+    dropped in next minor release, 2.3.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask>=1.1.1
+Flask>=2.2
 
 dimod>=0.10.0
 dwave-system>=1.3.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     'dimod>=0.10.0',
     'dwave-system>=1.3.0',
     'dwave-cloud-client>=0.8.3',
-    'Flask>=1.1.1',
+    'Flask>=2.2',
     'numpy',
     # dwave-inspectorapp==0.3.1
 ]


### PR DESCRIPTION
Method used so far is deprecated in current version of Flask (2.2) and will be dropped in 2.3.

Custom JSON serialization support changed in a backwards-incompatible way.