### PR TITLE
Use `vcrpy`-compatible version of `urllib3` (`<2`) for testing

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,9 @@
 coverage
 codecov
+
+# temporary fix for https://github.com/kevin1024/vcrpy/issues/688 is to
+# avoid urllib 2.x
+# NOTE: this should be a short-term fix, and the upper-bound removed as soon
+# as the new version of vcrpy is released.
 vcrpy
+urllib3<2


### PR DESCRIPTION
See issue description in #156.

See test failures in #155.