### PR TITLE
Migrate to codecov's orb from the deprecated uploader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,6 +301,7 @@ workflows:
                 dimod-preprocessing-version: "dimod~=0.10.0 dwave-preprocessing~=0.3.0"
               - python-version: "3.11.0"
                 dimod-preprocessing-version: "dimod~=0.11.0 dwave-preprocessing~=0.4.0"
+          context: &ctx-build "ocean-build"
           filters: &always-run  # run on `tags` in addition to `branches` default (deploy dep)
             tags:
               only: /.*/
@@ -331,6 +332,7 @@ workflows:
                 system-client-version: "dwave-system~=1.8.0 dwave-cloud-client==0.8.7"
               - python-version: "3.11.0"
                 system-client-version: "dwave-system~=1.9.0 dwave-cloud-client==0.9.0"
+          context: *ctx-build
           filters:
             <<: *always-run
 
@@ -338,6 +340,7 @@ workflows:
           matrix:
             parameters:
               python-version: *python-versions
+          context: *ctx-build
           filters:
             <<: *always-run
 
@@ -345,10 +348,12 @@ workflows:
           matrix:
             parameters:
               python-version: *python-versions
+          context: *ctx-build
           filters:
             <<: *always-run
 
       - test-docs:
+          context: *ctx-build
           filters:
             <<: *always-run
 
@@ -357,6 +362,7 @@ workflows:
             - test-linux
             - test-macos
             - test-windows
+          context: ocean-publish
           filters:
             tags:
               only: /^[0-9]+(\.[0-9]+)*((\.dev|rc)([0-9]+)?)?$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ parameters:
 
 orbs:
   win: circleci/windows@2.2.0
+  codecov: codecov/codecov@3
 
 environment:
   PIP_PROGRESS_BAR: 'off'
@@ -92,13 +93,13 @@ jobs:
 
       - run: &run-python-tests
           name: Run python tests
-          command: env/bin/coverage run -m unittest discover
-
-      - run: &upload-python-code-coverage
-          name: Upload code coverage
           command: |
             . env/bin/activate
-            codecov   # calls `coverage xml`, so we must activate venv
+            coverage run -m unittest discover
+            coverage xml
+
+      - codecov/upload: &upload-python-code-coverage
+          file: coverage.xml
 
   test-macos:
     parameters:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,4 @@
 coverage
-codecov
 
 # temporary fix for https://github.com/kevin1024/vcrpy/issues/688 is to
 # avoid urllib 2.x


### PR DESCRIPTION
For details, see https://github.com/dwavesystems/dwave-cloud-client/pull/543.