### PR TITLE
CI: don't restore venv on python patch version changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,13 @@ jobs:
     steps:
       - checkout
 
+      - run: &save-python-version
+          name: Save python version in file to be used as part of cache key
+          command: |
+            python -V > /tmp/python-V.txt
+
       - restore_cache: &restore-cache-env
-          key: v<< pipeline.parameters.cache-generation >>-pip-{{ checksum "requirements.txt" }}-{{ checksum "tests/requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
+          key: v<< pipeline.parameters.cache-generation >>-python-{{ checksum "/tmp/python-V.txt" }}-pip-{{ checksum "requirements.txt" }}-{{ checksum "tests/requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
 
       - run: &create-virtualenv
           name: Create virtual environment
@@ -50,7 +55,7 @@ jobs:
             pip install wheel twine
 
       - save_cache: &save-cache-env
-          key: v<< pipeline.parameters.cache-generation >>-pip-{{ checksum "requirements.txt" }}-{{ checksum "tests/requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
+          key: v<< pipeline.parameters.cache-generation >>-python-{{ checksum "/tmp/python-V.txt" }}-pip-{{ checksum "requirements.txt" }}-{{ checksum "tests/requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - env
 
@@ -142,6 +147,8 @@ jobs:
             - ~/.pyenv
 
       # install dependencies and cache them
+      - run: *save-python-version
+
       - restore_cache: *restore-cache-env
 
       - run: *create-virtualenv
@@ -255,13 +262,9 @@ jobs:
     steps:
       - checkout
 
-      - restore_cache: *restore-cache-env
-
       - run: *create-virtualenv
 
       - run: *install-requirements
-
-      - save_cache: *save-cache-env
 
       - run: *build-package
 


### PR DESCRIPTION
Include python version in venv cache key