### PR TITLE
Clean up deprecated solver params

### DIFF
--- a/dwave/inspector/adapters.py
+++ b/dwave/inspector/adapters.py
@@ -189,15 +189,12 @@ def _expand_params(solver, params=None, timing=None):
         "annealing_time": annealing_time,
         "answer_mode": params.get("answer_mode", "histogram"),
         "auto_scale": params.get("auto_scale", True if not flux_biases else False),
-        "beta": params.get("beta", 10 if solver.is_vfyc else 1),
-        "chains": params.get("chains"),
         "flux_biases": flux_biases,
         "flux_drift_compensation": params.get("flux_drift_compensation", True),
         "h_gain_schedule": params.get("h_gain_schedule", [[0, 1], [annealing_time, 1]]),
         "initial_state": initial_state,
         "max_answers": params.get("max_answers"),
         "num_reads": params.get("num_reads", 1),
-        "postprocess": params.get("postprocess", "sampling" if solver.is_vfyc else ""),
         "programming_thermalization": params.get("programming_thermalization", default_programming_thermalization),
         "readout_thermalization": params.get("readout_thermalization", default_readout_thermalization),
         "reduce_intersample_correlation": params.get("reduce_intersample_correlation", False),
@@ -207,6 +204,15 @@ def _expand_params(solver, params=None, timing=None):
     # num_spin_reversal_transforms has been removed from SAPI as of 2023-11-15
     if "num_spin_reversal_transforms" in solver.parameters:
         expanded.update(num_spin_reversal_transforms=params.get("num_spin_reversal_transforms", 0))
+
+    # post-processing and VFYC were last available on Chimera solvers, last
+    # of which (DW_2000Q_6) was decommissioned on 2023-05-31
+    if "postprocess" in solver.parameters:
+        expanded.update(postprocess=params.get("postprocess", "sampling" if solver.is_vfyc else ""))
+    if "beta" in solver.parameters:
+        expanded.update(beta=params.get("beta", 10 if solver.is_vfyc else 1))
+    if "chains" in solver.parameters:
+        expanded.update(chains=params.get("chains"))
 
     return expanded
 

--- a/dwave/inspector/adapters.py
+++ b/dwave/inspector/adapters.py
@@ -183,7 +183,7 @@ def _expand_params(solver, params=None, timing=None):
     # set each parameter individually because defaults are not necessarily
     # constant; they can depend on one or more other parameters
     # TODO: cast to primary types for safe JSON serialization
-    return {
+    expanded = {
         "anneal_offsets": params.get("anneal_offsets"),
         "anneal_schedule": anneal_schedule,
         "annealing_time": annealing_time,
@@ -197,13 +197,19 @@ def _expand_params(solver, params=None, timing=None):
         "initial_state": initial_state,
         "max_answers": params.get("max_answers"),
         "num_reads": params.get("num_reads", 1),
-        "num_spin_reversal_transforms": params.get("num_spin_reversal_transforms", 0),
         "postprocess": params.get("postprocess", "sampling" if solver.is_vfyc else ""),
         "programming_thermalization": params.get("programming_thermalization", default_programming_thermalization),
         "readout_thermalization": params.get("readout_thermalization", default_readout_thermalization),
         "reduce_intersample_correlation": params.get("reduce_intersample_correlation", False),
         "reinitialize_state": params.get("reinitialize_state", True if initial_state else False)
     }
+
+    # num_spin_reversal_transforms has been removed from SAPI as of 2023-11-15
+    if "num_spin_reversal_transforms" in solver.parameters:
+        expanded.update(num_spin_reversal_transforms=params.get("num_spin_reversal_transforms", 0))
+
+    return expanded
+
 
 def _validated_problem_data(data):
     "Basic types validation/conversion."

--- a/dwave/inspector/package_info.py
+++ b/dwave/inspector/package_info.py
@@ -39,7 +39,7 @@ contrib = [{
         'url': 'https://docs.ocean.dwavesys.com/eula',
     },
     'requirements': [
-        'dwave-inspectorapp==0.3.1',
+        'dwave-inspectorapp==0.3.2',
     ]
 }]
 

--- a/releasenotes/notes/omit-legacy-solver-params-dfb643c17593aefd.yaml
+++ b/releasenotes/notes/omit-legacy-solver-params-dfb643c17593aefd.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Omit legacy solver parameters, like ``num_spin_reversal_transforms`` and 
+    postprocessing params (``postprocess``, ``beta``, ``chains``) from the
+    visualizer.
+    See `#166 <https://github.com/dwavesystems/dwave-inspector/issues/166>`_ and
+    `#168 <https://github.com/dwavesystems/dwave-inspector/issues/168>`_.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requires = [
     'dwave-cloud-client>=0.8.3',    # for <0.10.6, also pydantic<2 is required!
     'Flask>=2.2',
     'numpy',
-    # dwave-inspectorapp==0.3.1
+    # dwave-inspectorapp==0.3.2
 ]
 
 # Package extras requirements


### PR DESCRIPTION
Omit solver legacy parameters from data passed to the visualizer unless a legacy solver is used.

Fix #166.
Fix #168.
