### PR TITLE
Add fast anneal protocol support

### DIFF
--- a/dwave/inspector/adapters.py
+++ b/dwave/inspector/adapters.py
@@ -160,6 +160,7 @@ def _expand_params(solver, params=None, timing=None):
     default_readout_thermalization = solver.properties['default_readout_thermalization']
 
     # figure out `annealing_time`
+    # (valid for fast anneal as well)
     if "qpu_anneal_time_per_sample" in timing:
         # actual value is known
         annealing_time = timing["qpu_anneal_time_per_sample"]
@@ -213,6 +214,10 @@ def _expand_params(solver, params=None, timing=None):
         expanded.update(beta=params.get("beta", 10 if solver.is_vfyc else 1))
     if "chains" in solver.parameters:
         expanded.update(chains=params.get("chains"))
+
+    # add fast anneal only if supported by the solver
+    if "fast_anneal" in solver.parameters:
+        expanded.update(fast_anneal=params.get("fast_anneal", False))
 
     return expanded
 

--- a/dwave/inspector/package_info.py
+++ b/dwave/inspector/package_info.py
@@ -39,7 +39,7 @@ contrib = [{
         'url': 'https://docs.ocean.dwavesys.com/eula',
     },
     'requirements': [
-        'dwave-inspectorapp==0.3.2',
+        'dwave-inspectorapp==0.3.3',
     ]
 }]
 

--- a/releasenotes/notes/add-fast-anneal-support-bc5f4dea77e3f561.yaml
+++ b/releasenotes/notes/add-fast-anneal-support-bc5f4dea77e3f561.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add support for fast anneal protocol. Display the new solver parameter
+    ``fast_anneal`` and the new solver property ``fast_anneal_time_range``
+    in the visualizer.
+    See `#170 <https://github.com/dwavesystems/dwave-inspector/issues/170>`_

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requires = [
     'dwave-cloud-client>=0.8.3',    # for <0.10.6, also pydantic<2 is required!
     'Flask>=2.2',
     'numpy',
-    # dwave-inspectorapp==0.3.2
+    # dwave-inspectorapp==0.3.3
 ]
 
 # Package extras requirements


### PR DESCRIPTION
Close #170.

Requires https://github.com/dwavesystems/problem-inspector-visualizer/pull/112, to be released as `dwave-inspectorapp==0.3.3`.