### PR TITLE
Optimize server performance

### DIFF
--- a/dwave/inspector/adapters.py
+++ b/dwave/inspector/adapters.py
@@ -98,19 +98,28 @@ def _get_solver_topology(solver, default=None):
 
     return default
 
-def solver_data_postprocessed(solver):
+def solver_data_postprocessed(solver, inplace=False):
     """Returns (possibly an old) solver's updated `data` that includes the
     missing properties like topology. Also, removes large unused properties.
+
+    Setting ``inplace`` flag will make permanent changes to ``solver`` data,
+    otherwise a copy will be returned.
     """
 
-    # make a copy to avoid modifying the original solver.data
-    data = copy.deepcopy(solver.data)
+    if inplace:
+        data = solver.data
+    else:
+        # make a copy to avoid modifying the original solver.data
+        data = copy.deepcopy(solver.data)
 
     # add missing but used properties
     data['properties'].setdefault('topology', _get_solver_topology(solver))
 
     # remove unused properties
-    del data['properties']['anneal_offset_ranges']
+    unused = {'anneal_offset_ranges'}
+    for key in unused:
+        if key in data['properties']:
+            del data['properties'][key]
 
     return data
 

--- a/dwave/inspector/server.py
+++ b/dwave/inspector/server.py
@@ -257,7 +257,7 @@ def send_problem(problem_id):
 @app.route('/api/problems/<problem_id>/solver')
 def send_solver(problem_id):
     try:
-        return get_solver_data(problem_store[problem_id]['details']['solver'])
+        return get_solver_data(problem_store[problem_id]['details']['solver'], update_inplace=True)
     except KeyError:
         raise NotFound
 

--- a/dwave/inspector/server.py
+++ b/dwave/inspector/server.py
@@ -34,7 +34,7 @@ from dwave.inspector.config import config
 from dwave.inspector.storage import (
     problem_store, problem_access_sem,
     get_last_problem_id, get_solver_data)
-from dwave.inspector.utils import NumpyJSONProvider
+from dwave.inspector.utils import OrJSONProvider
 
 
 # get local server/app logger
@@ -220,7 +220,7 @@ class WSGIAsyncServer(threading.Thread):
 
 
 app = Flask(__name__, static_folder=None)
-app.json = NumpyJSONProvider(app)
+app.json = OrJSONProvider(app)
 
 @app.route('/ping')
 def ping():

--- a/dwave/inspector/storage.py
+++ b/dwave/inspector/storage.py
@@ -157,11 +157,11 @@ def get_last_problem_id() -> Optional[str]:
     return next(reversed(problem_store))
 
 
-def get_solver_data(solver_id):
+def get_solver_data(solver_id, update_inplace=False):
     """Return solver data dict for `solver_id`. If solver hasn't been seen in
     any of the problems cached so far, fail with :exc:`KeyError`.
     """
     if solver_id in solvers:
-        return solver_data_postprocessed(solvers[solver_id])
+        return solver_data_postprocessed(solvers[solver_id], inplace=update_inplace)
 
     raise KeyError('solver not found')

--- a/dwave/inspector/utils.py
+++ b/dwave/inspector/utils.py
@@ -186,7 +186,7 @@ def update_url_from(url: Union[str, ParseResult],
     """
 
     # handle schemeless urls -> assume http
-    if not re.match("^\w+://", url):
+    if not re.match(r"^\w+://", url):
         url = f"http://{url}"
 
     # deconstruct source and patch urls

--- a/dwave/inspector/utils.py
+++ b/dwave/inspector/utils.py
@@ -18,7 +18,7 @@ import logging
 import operator
 import functools
 
-from typing import Sequence, Callable, Optional, Union, Dict
+from typing import Sequence, Callable, Optional, Union, Dict, Any
 from urllib.parse import urlparse, ParseResult
 
 try:
@@ -26,11 +26,11 @@ try:
 except ImportError: # pragma: no cover
     from importlib_metadata import EntryPoint, DistributionFinder, Distribution
 
-import flask
-import numpy
+from flask.json.provider import JSONProvider
+import orjson
 
 __all__ = [
-    'itemsgetter', 'annotated', 'NumpyJSONProvider', 'patch_entry_points',
+    'itemsgetter', 'annotated', 'OrJSONProvider', 'patch_entry_points',
     'RichDisplayURL',
 ]
 
@@ -80,29 +80,22 @@ def annotated(**kwargs):
     return _decorator
 
 
-# adapted from dwave-hybrid utils
-# (https://github.com/dwavesystems/dwave-hybrid/blob/b9025b5bb3d88dce98ec70e28cfdb25400a10e4a/hybrid/utils.py#L43-L61)
-# to provide numpy types serialization in flask 2.2+ (see https://github.com/pallets/flask/pull/4692)
-class NumpyJSONProvider(flask.json.provider.DefaultJSONProvider):
-    """JSON encoder for numpy types.
+# provide faster json serialization in flask 2.2+, with numpy support
+# (see https://github.com/pallets/flask/pull/4692)
+class OrJSONProvider(JSONProvider):
+    """Flask-specialized JSON encoder/decoder that uses ``orjson``.
 
-    Supported types:
-     - basic numeric types: booleans, integers, floats
-     - arrays: ndarray, recarray
+    By default, NumPy types are serialized, and non-string keys are supported.
     """
 
-    @staticmethod
-    def default(obj):
-        if isinstance(obj, numpy.integer):
-            return int(obj)
-        elif isinstance(obj, numpy.floating):
-            return float(obj)
-        elif isinstance(obj, numpy.bool_):
-            return bool(obj)
-        elif isinstance(obj, numpy.ndarray):
-            return obj.tolist()
+    def loads(self, s: str, **kwargs: Any) -> Any:
+        return orjson.loads(s, **kwargs)
 
-        return super().default(obj)
+    def dumps(self, obj: Any, **kwargs: Any) -> bytes:
+        kwargs.setdefault('option', (orjson.OPT_SERIALIZE_NUMPY
+                                     | orjson.OPT_NON_STR_KEYS
+                                     | orjson.OPT_NAIVE_UTC))
+        return orjson.dumps(obj, **kwargs)
 
 
 # TODO: move to `dwave.common.testing` or similar

--- a/releasenotes/notes/optimize-server-perf-ff824880020e0e9c.yaml
+++ b/releasenotes/notes/optimize-server-perf-ff824880020e0e9c.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Improve performance of the inspector server by postprocessing solver data
+    inplace, saving one deep copy of solver metadata (~600kB for Advantage) on
+    each API request of solver data.

--- a/releasenotes/notes/optimize-server-perf-ff824880020e0e9c.yaml
+++ b/releasenotes/notes/optimize-server-perf-ff824880020e0e9c.yaml
@@ -4,3 +4,13 @@ fixes:
     Improve performance of the inspector server by postprocessing solver data
     inplace, saving one deep copy of solver metadata (~600kB for Advantage) on
     each API request of solver data.
+
+features:
+  - |
+    Replace builtin JSON encoder with ``orjson``, achieving 2-5x speed-up of
+    problem and solver API endpoints.
+
+upgrade:
+  - |
+    ``dwave.inspector.utils.NumpyJSONProvider`` is removed and no longer available.
+    Use ``orjson.dumps`` with ``option=orjson.OPT_SERIALIZE_NUMPY`` instead.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ dimod>=0.10.0
 dwave-system>=1.3.0
 dwave-cloud-client>=0.8.3
 numpy    # comes with dimod, but be explicit
+orjson>=3.10.0
 
 # backports
 importlib-resources>=3.2.0; python_version<"3.9"

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ install_requires = [
     'dwave-cloud-client>=0.8.3',    # for <0.10.6, also pydantic<2 is required!
     'Flask>=2.2',
     'numpy',
+    'orjson>=3.10.0',
     # dwave-inspectorapp==0.3.3
 ]
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
 coverage
+parameterized
 
 # temporary fix for https://github.com/kevin1024/vcrpy/issues/688 is to
 # avoid urllib 2.x

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -53,7 +53,7 @@ class TestStorage(unittest.TestCase):
         push_inspector_data(inspector_data)
 
         # get solver data
-        solver_data = get_solver_data(solver.id)
+        solver_data = get_solver_data(solver.id, update_inplace=False)
 
         # verify missing data is recreated
         self.assertIn('topology', solver_data['properties'])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import unittest
 
 from uuid import uuid4
 from urllib.parse import ParseResult, urlparse, urljoin
 
-from dwave.inspector.utils import itemsgetter, annotated, update_url_from
+import numpy
+from parameterized import parameterized
+
+from dwave.inspector.utils import itemsgetter, annotated, update_url_from, OrJSONProvider
 
 
 class TestItemsgetter(unittest.TestCase):
@@ -103,3 +107,52 @@ class TestUrlRewrite(unittest.TestCase):
         src, dst = 'http://localhost:9000/local', 'https://example.com/external/'
         url = update_url_from(src, dst, path=lambda src, dst: urljoin(dst.path, src.path.lstrip('/')))
         self.assertEqual(url, 'https://example.com/external/local')
+
+
+# adapted from dwave-hybrid utils
+# (https://github.com/dwavesystems/dwave-hybrid/blob/b9025b5bb3d88dce98ec70e28cfdb25400a10e4a/hybrid/utils.py#L43-L61)
+class TestOrJSONProvider(unittest.TestCase):
+
+    @parameterized.expand([
+        (numpy.bool_(1), True), (numpy.bool8(1), True),
+        (numpy.byte(1), 1), (numpy.int8(1), 1),
+        (numpy.ubyte(1), 1), (numpy.uint8(1), 1),
+        (numpy.short(1), 1), (numpy.int16(1), 1),
+        (numpy.ushort(1), 1), (numpy.uint16(1), 1),
+        (numpy.intc(1), 1), (numpy.int32(1), 1),
+        (numpy.uintc(1), 1), (numpy.uint32(1), 1),
+        (numpy.int_(1), 1), (numpy.int32(1), 1),
+        (numpy.uint(1), 1), (numpy.uint32(1), 1),
+        (numpy.int64(1), 1),
+        (numpy.uint64(1), 1),
+        (numpy.half(1.0), 1.0), (numpy.float16(1.0), 1.0),
+        (numpy.single(1.0), 1.0), (numpy.float32(1.0), 1.0),
+        (numpy.double(1.0), 1.0), (numpy.float64(1.0), 1.0),
+        # note: orjson does not currently support: longlong, ulonglong, longdouble
+        # see https://github.com/ijl/orjson/issues/469
+    ])
+    def test_numpy_primary_type_encode(self, np_val, py_val):
+        provider = OrJSONProvider(app=self)
+        self.assertEqual(
+            json.dumps(py_val, separators=(',', ':')).encode(),
+            provider.dumps(np_val)
+        )
+
+    @parameterized.expand([
+        (numpy.array([1, 2, 3], dtype=int), [1, 2, 3]),
+        (numpy.array([[1], [2], [3]], dtype=float), [[1.0], [2.0], [3.0]]),
+        (numpy.zeros((2, 2), dtype=bool), [[False, False], [False, False]]),
+        # note: recarrays are not support by orjson. if needed, we can add support via default callback
+        # (numpy.array([('Rex', 9, 81.0), ('Fido', 3, 27.0)],
+        #              dtype=[('name', 'U10'), ('age', 'i4'), ('weight', 'f4')]),
+        #  [['Rex', 9, 81.0], ['Fido', 3, 27.0]]),
+        # (numpy.rec.array([(1, 2., 'Hello'), (2, 3., "World")],
+        #                  dtype=[('foo', 'i4'), ('bar', 'f4'), ('baz', 'U10')]),
+        #  [[1, 2.0, "Hello"], [2, 3.0, "World"]])
+    ])
+    def test_numpy_array_encode(self, np_val, py_val):
+        provider = OrJSONProvider(app=self)
+        self.assertEqual(
+            json.dumps(py_val, separators=(',', ':')).encode(),
+            provider.dumps(np_val)
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -119,8 +119,8 @@ class TestOrJSONProvider(unittest.TestCase):
         (numpy.ubyte(1), 1), (numpy.uint8(1), 1),
         (numpy.short(1), 1), (numpy.int16(1), 1),
         (numpy.ushort(1), 1), (numpy.uint16(1), 1),
-        (numpy.intc(1), 1), (numpy.int32(1), 1),
-        (numpy.uintc(1), 1), (numpy.uint32(1), 1),
+        (numpy.int32(1), 1),
+        (numpy.uint32(1), 1),
         (numpy.int_(1), 1), (numpy.int32(1), 1),
         (numpy.uint(1), 1), (numpy.uint32(1), 1),
         (numpy.int64(1), 1),
@@ -128,7 +128,7 @@ class TestOrJSONProvider(unittest.TestCase):
         (numpy.half(1.0), 1.0), (numpy.float16(1.0), 1.0),
         (numpy.single(1.0), 1.0), (numpy.float32(1.0), 1.0),
         (numpy.double(1.0), 1.0), (numpy.float64(1.0), 1.0),
-        # note: orjson does not currently support: longlong, ulonglong, longdouble
+        # note: orjson does not currently support: longlong, ulonglong, longdouble, intc, uintc
         # see https://github.com/ijl/orjson/issues/469
     ])
     def test_numpy_primary_type_encode(self, np_val, py_val):


### PR DESCRIPTION
By switching to `orjson` and avoiding solver data copy, we achieve 2-3x speed-up of data requests from the visualizer app to the inspector server.

On my laptop, when inspecting on localhost, in Chrome, I'm observing page load time dropping from ~1.3s to ~0.5s.