### PR TITLE
Relax Flask version requirement to include 3.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask>=2.2,<3
+Flask>=2.2,<4
 
 dimod>=0.10.0
 dwave-system>=1.3.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     'dimod>=0.10.0',
     'dwave-system>=1.3.0',
     'dwave-cloud-client>=0.11.0,<0.12.0',
-    'Flask>=2.2,<3',
+    'Flask>=2.2,<4',
     'numpy',
     'orjson>=3.10.0',
     # dwave-inspectorapp==0.3.3


### PR DESCRIPTION
Flask 3.0.0 contains no real major breaks, except some deprecated code removal (which we didn't use anyway).