### PR TITLE
Fix link located outside include directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 .coverage
 htmlcov/
 coverage.xml
+*.egg-info*
 
 env/
 build/

--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,9 @@ and then install the closed-source dependency with:
 
     pip install dwave-inspectorapp --extra-index=https://pypi.dwavesys.com/simple
 
-Please note this closed-source dependency is released under the `D-Wave EULA`_ license.
+Please note this closed-source dependency is released under the 
+`D-Wave EULA <https://docs.ocean.dwavesys.com/en/stable/licenses/inspector.html>`_ 
+license.
 
 Alternatively, clone and build from source:
 
@@ -100,10 +102,8 @@ License
 
 Released under the Apache License 2.0. See `<LICENSE>`_ file.
 
-Visualization component released under the `D-Wave EULA`_.
-
-.. _D-Wave EULA: https://docs.ocean.dwavesys.com/en/stable/licenses/inspector.html
-
+Visualization component released under the 
+`D-Wave EULA <https://docs.ocean.dwavesys.com/en/stable/licenses/inspector.html>`_.
 
 Contributing
 ============


### PR DESCRIPTION
Part of [sdk](https://github.com/dwavesystems/dwave-ocean-sdk/pull/300) cleanup of build warnings. 
The first indirect link is located between the `.. installation-start-marker` and `.. installation-end-marker` block that is pulled out in the SDK but the definition of the target is located outside that block, so the included section has an undefined link. In the SDK build this causes a warning:

```
docs_inspector/README.rst:21: ERROR: Unknown target name: "d-wave eula".
```