### PR TITLE
Fix `Solver.data` if passed as pydantic model

### DIFF
--- a/dwave/inspector/server.py
+++ b/dwave/inspector/server.py
@@ -117,6 +117,9 @@ class InspectorAppServer(BackgroundAppServer):
     def get_problem_url(self, problem_id):
         return urljoin(self.root_url, f'/api/problems/{problem_id}')
 
+    def get_solver_url(self, problem_id):
+        return urljoin(self.root_url, f'/api/problems/{problem_id}/solver')
+
 
 app = Flask(__name__, static_folder=None)
 app.json = OrJSONProvider(app)

--- a/dwave/inspector/storage.py
+++ b/dwave/inspector/storage.py
@@ -110,6 +110,9 @@ def add_problem(problem, solver, response):
 
 
 def add_solver(solver):
+    # convert pydantic SolverConfiguration model if used instead of dict for data
+    if callable(getattr(solver.data, 'model_dump', None)):
+        solver.data = solver.data.model_dump()
     solvers[solver.id] = solver
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -117,6 +117,26 @@ class TestProblemOpen(unittest.TestCase, RunTimeAssertionMixin):
             show(self.response, block=Block.ONCE)
 
     @unittest.mock.patch('dwave.inspector.view', lambda url: None)
+    def test_api_access(self):
+        # push data, for server to be able to fetch it
+        show(self.response, block=Block.NEVER)
+
+        # verify problem data access
+        url = app_server.get_problem_url(self.problem_id)
+        res = requests.get(url)
+        self.assertEqual(res.status_code, 200)
+
+        # verify solver data access
+        url = app_server.get_solver_url(self.problem_id)
+        res = requests.get(url)
+        self.assertEqual(res.status_code, 200)
+
+        # verify problem data access
+        url = app_server.get_callback_url(self.problem_id)
+        res = requests.get(url)
+        self.assertEqual(res.status_code, 200)
+
+    @unittest.mock.patch('dwave.inspector.view', lambda url: None)
     def test_redirect_root_to_last_problem(self):
         # push data, for server to be able to fetch it
         show(self.response, block=Block.NEVER)


### PR DESCRIPTION
Follow-up to #181, where I forgot to handle solver data in a Pydantic model (cloud-client 0.13 thing).